### PR TITLE
32-bit support, redundant code removal

### DIFF
--- a/Firmware/MMA8452Q_BasicExample/MMA8452Q_BasicExample.ino
+++ b/Firmware/MMA8452Q_BasicExample/MMA8452Q_BasicExample.ino
@@ -22,6 +22,7 @@
  The MMA8452 has built in pull-up resistors for I2C so you do not need additional pull-ups.
  */
 
+#include <limits.h>
 #include <Wire.h> // Used for I2C
 
 // The SparkFun breakout board defaults to 1, set to 0 if SA0 jumper on the bottom of the board is set
@@ -78,6 +79,10 @@ void readAccelData(int *destination)
   for(int i = 0; i < 3 ; i++)
   {
     int gCount = (rawData[i*2] << 8) | rawData[(i*2)+1];  //Combine the two 8 bit registers into one 12-bit number
+#if INT_MAX == 0x7fffffff  // sign-extend on 32-bit processors like Teensy 3
+    if (gCount & 0x8000)
+      gCount |= 0xffff0000;
+#endif
     gCount >>= 4; //The registers are left align, here we right align the 12-bit integer
 
     destination[i] = gCount; //Record this gCount into the 3 int array


### PR DESCRIPTION
This change makes the basic MMA8452 example work properly on 32-bit boards.  Tested on a Teensy 3 and confirmed to still work on an ATmega328-based Arduino clone.

Also removed a double negation of gCount:

```
gCount = ~gCount + 1;  // bitwise negation of gCount
gCount *= -1;          // arithmetic negation of gCount
```

So why does the code work anyway?  Because in C a right-shift on a signed integer is an arithmetic shift, meaning it handles negative numbers the way you would want for gCount in this application; (-4 >> 1) == -2.
