### PR TITLE
Fix code for handling sign extension of negative 12-bit values.

### DIFF
--- a/Firmware/MMA8452Q_AdvancedExample/MMA8452Q_AdvancedExample.ino
+++ b/Firmware/MMA8452Q_AdvancedExample/MMA8452Q_AdvancedExample.ino
@@ -142,8 +142,7 @@ void readAccelData(int * destination)
     if (rawData[i] > 0x7F)
     {  
       // If the number is negative, we have to make it so manually (no 12-bit data type)
-      destination[i/2] = ~destination[i/2] + 1;
-      destination[i/2] *= -1;  // Transform into negative 2's complement #
+      destination[i/2] -= 0x1000;
     }
   }
 }

--- a/Firmware/MMA8452Q_BasicExample/MMA8452Q_BasicExample.ino
+++ b/Firmware/MMA8452Q_BasicExample/MMA8452Q_BasicExample.ino
@@ -83,8 +83,7 @@ void readAccelData(int *destination)
     // If the number is negative, we have to make it so manually (no 12-bit data type)
     if (rawData[i*2] > 0x7F)
     {  
-      gCount = ~gCount + 1;
-      gCount *= -1;  // Transform into negative 2's complement #
+      gCount -= 0x1000;
     }
 
     destination[i] = gCount; //Record this gCount into the 3 int array


### PR DESCRIPTION
Previous code was incorrect; this code is also faster and simpler

Example: 
  gCount = 0xfff.

Old code:
  ~gCount = 0xf000
  ~gCount + 1 = 0xf001
- ( ~gCount + 1 ) = 0x1001

New code:
  0xfff - 0x1000 = 0xffff
