### PR TITLE
Negative numbers display fix

### DIFF
--- a/Firmware/libraries/SFE_MMA8452Q/SFE_MMA8452Q.cpp
+++ b/Firmware/libraries/SFE_MMA8452Q/SFE_MMA8452Q.cpp
@@ -77,9 +77,9 @@ void MMA8452Q::read()
 
 	readRegisters(OUT_X_MSB, rawData, 6);  // Read the six raw data registers into data array
 	
-	x = (rawData[0]<<8 | rawData[1]) >> 4;
-	y = (rawData[2]<<8 | rawData[3]) >> 4;
-	z = (rawData[4]<<8 | rawData[5]) >> 4;
+	x = ((short)(rawData[0]<<8 | rawData[1])) >> 4;
+	y = ((short)(rawData[2]<<8 | rawData[3])) >> 4;
+	z = ((short)(rawData[4]<<8 | rawData[5])) >> 4;
 	cx = (float) x / (float)(1<<11) * (float)(scale);
 	cy = (float) y / (float)(1<<11) * (float)(scale);
 	cz = (float) z / (float)(1<<11) * (float)(scale);

--- a/Firmware/libraries/SFE_MMA8452Q/SFE_MMA8452Q.h
+++ b/Firmware/libraries/SFE_MMA8452Q/SFE_MMA8452Q.h
@@ -97,7 +97,7 @@ public:
 	byte readTap();
 	byte readPL();
 	
-    int x, y, z;
+    short x, y, z;
 	float cx, cy, cz;
 private:
 	byte address;


### PR DESCRIPTION
Currently the negative values were displayed incorrectly and for example for values +/-2g the values were 0g to 4g.